### PR TITLE
Example Changes to make card larger

### DIFF
--- a/mini-media-player.js
+++ b/mini-media-player.js
@@ -354,6 +354,17 @@ class MiniMediaPlayer extends LitElement {
           padding: 16px;
           position: relative;
         }
+
+        ha-card[has-artwork] {
+          height: 250px !important;
+        }
+        ha-card[has-artwork] #mediacontrols {
+          left: 16px;
+          right: 16px;
+          bottom: 16px;
+          position: absolute !important;
+          margin-left: 0px !important;
+        }
         ha-card header {
           display: none;
         }


### PR DESCRIPTION
Here are just some small example changes, that will make the card look like (below) with the following example card config.
```yaml
- entity: media_player.spotify
  type: "custom:mini-media-player"
  artwork: cover
```

<img width="496" alt="screenshot 2018-09-28 at 20 56 55" src="https://user-images.githubusercontent.com/457678/46228284-eb328200-c361-11e8-9a36-a7118077fb9c.png">
